### PR TITLE
Use `editorLineNumber.activeForeground` for highlighted line numbers

### DIFF
--- a/webview/src/code.js
+++ b/webview/src/code.js
@@ -99,20 +99,20 @@ function toggleLineHighlight(e) {
   if(this.parentNode.parentNode.classList.contains("line-highlight")) {
     this.parentNode.parentNode.classList.remove("line-highlight");
     this.parentNode.parentNode.classList.add("line-highlight-git-add");
-    this.classList.add('!text-white')
+    this.parentNode.parentNode.firstChild.classList.add('line-number-highlight')
   } else if (this.parentNode.parentNode.classList.contains("line-highlight-git-add")) {
     this.parentNode.parentNode.classList.remove("line-highlight-git-add");
     this.parentNode.parentNode.classList.add("line-highlight-git-remove");
-    this.classList.add('!text-white')
+    this.parentNode.parentNode.firstChild.classList.add('line-number-highlight')
   } else if (this.parentNode.parentNode.classList.contains("line-highlight-git-remove")) {
     this.parentNode.parentNode.classList.remove("line-highlight");
     this.parentNode.parentNode.classList.remove("line-highlight-git-add");
     this.parentNode.parentNode.classList.remove("line-highlight-git-remove");
-    this.classList.remove('text-white')
+    this.parentNode.parentNode.firstChild.classList.remove('line-number-highlight')
   } else {
     this.parentNode.parentNode.classList.add("line-highlight");
     this.parentNode.parentNode.classList.remove("line-highlight-git-add");
     this.parentNode.parentNode.classList.remove("line-highlight-git-remove");
-    this.classList.add('!text-white')
+    this.parentNode.parentNode.firstChild.classList.add('line-number-highlight')
   }
 };

--- a/webview/style.css
+++ b/webview/style.css
@@ -255,3 +255,7 @@ button {
   color: rgb(239 68 68);  
   content: "-";
 }
+
+.line-number-highlight {
+  color: var(--vscode-editorLineNumber-activeForeground)
+}


### PR DESCRIPTION
When highlighting a line the line number becomes harder to see, making it difficult to refer to when referencing the image.
The prior version of CodeSnap set the line number to bright white, but that doesn't necessarily match the theme of the editor.

Here, we're using VS Code's `editorLineNumber.activeForeground` color to style the line number on highlighted lines. This makes the line number clear while still fitting within the editor's color theme.

### Before
![image](https://user-images.githubusercontent.com/454563/204934966-b8b5814a-8b1a-4aca-a56f-fe10260a57b9.png)
### After
![image](https://user-images.githubusercontent.com/454563/204933857-1f29a515-f4a8-49a4-acfc-c5b18ede8780.png)

